### PR TITLE
Add disclaimer to README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2 +1,3 @@
 # Version v0.0.0
 
+- Add disclaimer to README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,3 @@
 # Version v0.0.0
 
-- Add disclaimer to README.md
+- Add disclaimer to README.md #5

--- a/README.md
+++ b/README.md
@@ -3,18 +3,33 @@
 Open source Qt tools for the development of GUIs. 
 Collaboration between STFC Scientific Computing, STFC ISIS, STFC Central Laser Facility, Diamond.
 
-#### Note:
+**Note:**
+
 Qt-collaboration uses the [`qtpy`](https://github.com/spyder-ide/qtpy) abstraction layer for Qt bindings, meaning that it works with either PySide or PyQt bindings. Thus, the package does not depend on either. If the environment does not already have a Qt binding then the user *must* install either `pyside2` or `pyqt5` or `pyqt6`.
+
+## ⚠️ Disclaimer ⚠️
+
+The content of this repository is exploratory and is intended for development, demonstration, and educational purposes only. It is a collaborative space for sharing code snippets and exploring ideas related to Qt5 and Qt6.
+
+**Please be aware of the following:**
+
+* **Developmental Code:** All code, examples, and snippets within this repository are considered to be in a pre-release, developmental state. They are not final, may be incomplete, and are subject to change without notice.
+
+* **No Guarantees or Warranties:** The code is provided "AS IS", without warranty of any kind, express or implied, including but not limited to the warranties of merchantability, fitness for a particular purpose, and noninfringement. In no event shall the authors or copyright holders be liable for any claim, damages, or other liability, whether in an action of contract, tort, or otherwise, arising from, out of, or in connection with the software or the use or other dealings in the software.
+
+* **Not for Production Use:** This code is not intended for use in production environments. Any use of this code in a live system is at your own risk.
+
+This repository is meant to be a helpful resource for the community, but it does not represent a finished or officially endorsed product.
 
 ## Examples
 
 See the [`examples`](examples) directory.
 
 ## Documentation
-See [Documentation.md](./Documentation.md).
+See [`Documentation.md`](./Documentation.md).
 
 ## Developer Contribution Guide
-Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md).
+Contributions are welcome. See [`CONTRIBUTING.md`](./CONTRIBUTING.md).
 
 
 


### PR DESCRIPTION
Add a disclaimer to the repository's READMe.md as per suggestions from the previous meeting. 

The disclaimer makes clear that the contents of the repository are exploratory and as such there is no guarantees in terms of functionality. 